### PR TITLE
Update Juno Styles

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -18,7 +18,7 @@ if ( ! function_exists( 'juno_setup' ) ) :
 function juno_setup() {
     
         if( !defined( 'JUNO_VERSION' ) ) :
-            define( 'JUNO_VERSION', '1.0.5' );
+            define( 'JUNO_VERSION', '1.0.6' );
         endif;
     
 	/*

--- a/inc/css/style.css
+++ b/inc/css/style.css
@@ -9,11 +9,20 @@ a {
     text-decoration: none !important;
 }
 
-a.accent-button {
+a.accent-button,
+input.accent-button {
     text-transform: uppercase;
     padding: 15px 30px;
     color: #fff;
     border-radius: 5px;
+    font-size: 14px;
+    display: inline-block;
+}
+
+input.accent-button {
+    border: none;
+    box-shadow: none !important;
+    text-shadow: none !important;
 }
 
 *:focus {
@@ -37,10 +46,12 @@ div#site-branding {
     text-transform: uppercase;
     letter-spacing: .5em;
     font-size: 40px;
+    display: block;
 }
 
 header#masthead img.custom-logo {
     width: auto;
+    margin-bottom: 30px;
 }
 
 /*
@@ -283,7 +294,7 @@ a.slicknav_btn {
 }
 
 .camera_caption p.slide-content {
-    font-weight: 100;
+    font-weight: 300;
     font-size: 16px;
     width: 70%;
     margin: 20px auto;
@@ -365,6 +376,7 @@ div#about-section {
     font-weight: 700;
     font-size: 16px;
     margin-bottom: 20px;
+    padding-bottom: 3px;
 }
 
 #about-section .widget {
@@ -389,15 +401,17 @@ div#subscribe-module {
 }
 
 #subscribe-module input[type="text"], 
-#subscribe-module input[type="email"] {
-    height: 50px;
+#subscribe-module input[type="email"],
+#subscribe-module textarea {
+/*    height: 50px;
     box-shadow: none;
     text-shadow: none;
     border: none;
     padding: 0 15px;
     border-radius: 5px;
     min-width: 50%;
-    margin-right: 5px;
+    margin-right: 5px;*/
+    border-color: #fff;
 }
 
 #subscribe-module input[type="submit"] {
@@ -410,7 +424,6 @@ div#subscribe-module {
     box-shadow: none;
     text-shadow: none;
     border: none;
-    height: 50px;
 } 
 
 #subscribe-module .widget .widget-title {
@@ -648,6 +661,11 @@ div#single-title-box .post-meta {
     margin-top: 5px;
 }
 
+div#single-title-box .post-meta,
+div#single-title-box .post-meta a {
+    color: #fff;
+}
+
 #single-post-container .entry-content {
     margin: 0;
     padding: 30px;
@@ -841,6 +859,7 @@ a#cancel-comment-reply-link {
 /*
 ** Left and Right Sidebars -----------------------------------------------------
 */
+.home.blog .sidebar-container,
 #archive-blog .sidebar-container,
 #single-post-container .sidebar-container,
 #single-page-container .sidebar-container,
@@ -850,10 +869,12 @@ a#cancel-comment-reply-link {
 
 .sidebar-container aside#secondary.widget-area {
     background: #f5f5f5;
+    padding-top: 30px;
 }
 
 .sidebar-container .widget {
-    padding: 30px;
+    padding: 0 30px;
+    margin-bottom: 30px;
 }
 
 /*
@@ -874,7 +895,11 @@ a#cancel-comment-reply-link {
 }
 
 .widgettitle,
-.widget-title {
+.widget-title,
+#subscribe-module h6.feature-title,
+.front-page-widget h6.feature-title,
+#footer-widget-area h6.feature-title,
+.sidebar-container h6.feature-title {
     margin-top: 5px;
     text-transform: uppercase;
     font-weight: 700;
@@ -922,6 +947,9 @@ div.social-bubble {
     line-height: 40px;
     font-size: 14px;
     border: 2px solid #fff;
+    transition: 0.3s all ease-in-out;
+    -moz-transition: 0.3s all ease-in-out;
+    -webkit-transition: 0.3s all ease-in-out;
 }
 
 div.social-bubble i {
@@ -1037,7 +1065,7 @@ footer#colophon div#footer-branding {
     text-align: center;
     color: #fff;
     font-size: 12px;
-    padding: 15px 0 0 0;
+    padding: 15px 0 15px 0;
 }
 
 footer#colophon div#footer-branding img {
@@ -1059,12 +1087,18 @@ div#footer-jumper span {
     cursor: pointer;
     border-radius: 3px;
     border: 2px solid rgba(255,255,255,.75);
-    margin: 10px 0;
+    margin: 0 0 10px 0;
 }
 
 div#footer-jumper span:hover {
     color: #fff;
     border-color: #fff;
+}
+
+div#footer-jumper span.word-jumper {
+    border: none;
+    display: inline-block;
+    width: 120px;
 }
 
 /*
@@ -1313,3 +1347,121 @@ footer .widget_calendar table tfoot td {
     padding: 0 15px 15px 15px;
     background-color: #fff;
 }
+
+
+
+
+
+/*
+ * Widgets New Spacing --------------------------------------------------------
+ */
+
+.widget .detail {
+    margin-bottom: 15px;
+    font-weight: 300;
+}
+#subscribe-module h6.feature-title {
+    border-bottom: thin solid;
+}
+#footer-widget-area h6.feature-title {
+    border-bottom: thin solid #fff;
+}
+
+#about-section .widget a.accent-button {
+    margin: 0px 0px;
+}
+
+#subscribe-module .widget,
+#footer-widget-area .widget,
+section.front-page-widget .widget {
+    margin-bottom: 30px;
+}
+
+.widget ul {
+    list-style: none;
+    padding: 0;
+}
+
+.widget ul a {
+    font-weight: 400;
+    color: #333;
+    transition: 0.3s all ease-in-out;
+    -moz-transition: 0.3s all ease-in-out;
+    -webkit-transition: 0.3s all ease-in-out;
+}
+
+.widget_categories ul a {
+    transition: none;
+    -moz-transition: none;
+    -webkit-transition: none;
+}
+
+.widget_tag_cloud a {
+    transition: 0.3s all ease-in-out;
+    -moz-transition: 0.3s all ease-in-out;
+    -webkit-transition: 0.3s all ease-in-out;   
+    color: #333;
+}
+
+.widget_search label, .widget_search input.search-field {
+    width: 100%;
+}
+
+.widget_search input.search-field {
+    border-radius: 0;
+    padding: 5px;
+    transition: 0.3s all ease-in-out;
+    -moz-transition: 0.3s all ease-in-out;
+    -webkit-transition: 0.3s all ease-in-out;
+    color: #666;
+    border: 1px solid #ccc;
+    font-weight: 300;
+    margin-bottom: 10px;
+}
+
+.widget_search input.search-field:focus {
+    border-color: #333;
+}
+
+.widget_search input.search-submit {
+    margin: 0;
+}
+
+#subscribe-module .widget ul a {
+    color: #fff;
+}
+#subscribe-module .widget ul a:hover {
+    color: #333;
+}
+
+#subscribe-module .widget_search input.search-field,
+#footer-widget-area .widget_search input.search-field {
+    border: 1px solid #fff;
+}
+
+#subscribe-module .widget_search input.search-field:focus,
+#footer-widget-area .widget_search input.search-field:focus {
+    border-color: #333;
+}
+
+#subscribe-module .widget_search input[type="submit"] {
+    padding: 0 20px;
+}
+
+#subscribe-module .widget_tag_cloud a {
+    color: #fff;
+}
+
+#subscribe-module .widget_tag_cloud a:hover {
+    color: #333;
+}
+
+.widget.widget_search form.search-form {
+    padding-top: 0;
+}
+
+#footer-widget-area .widget ul a:hover,
+#footer-widget-area .widget_tag_cloud a:hover {
+    color: #fff;
+}
+

--- a/inc/juno/juno.php
+++ b/inc/juno/juno.php
@@ -155,7 +155,7 @@ function juno_custom_css() { ?>
         }
         
         header#masthead img.custom-logo { 
-            height: <?php echo intval( get_theme_mod( 'juno_custom_logo_height', 50 ) ); ?>px;
+            max-height: <?php echo intval( get_theme_mod( 'juno_custom_logo_height', 50 ) ); ?>px;
         }
         
         /* ---------- FONT FAMILIES ---------- */
@@ -215,8 +215,10 @@ function juno_custom_css() { ?>
         }
         .widgettitle,
         .widget-title,
-        #front-page-blog div#frontpage-page .entry-title {
-            border-bottom: thin solid <?php echo esc_attr( $skin[ 'dark' ] ); ?>;
+        #front-page-blog div#frontpage-page .entry-title,
+        .front-page-widget h6.feature-title,
+        .sidebar-container h6.feature-title {
+            border-bottom: #333;
         }
         
         footer .widget_calendar table th,
@@ -247,7 +249,8 @@ function juno_custom_css() { ?>
         div#footer-widget-area a,
         .widget_calendar table a,
         .widget_calendar caption,
-        footer .widget_calendar caption {
+        footer .widget_calendar caption,
+        .widget a:hover {
             color: <?php echo esc_attr( $skin[ 'primary' ] ); ?>;
         }
         footer#colophon #footer-sidebar-wrapper {
@@ -267,10 +270,6 @@ function juno_custom_css() { ?>
         input.search-submit,
         .error-404 input.search-submit {
             background-color: <?php echo esc_attr( $skin[ 'accent' ] ); ?>;
-        }
-        div#single-title-box .post-meta,
-        div#single-title-box .post-meta a { 
-            color: <?php echo esc_attr( $skin[ 'accent' ] ); ?>; 
         }
         input.search-field,
         .error-404 input.search-field,

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: one-column, two-columns, three-columns, left-sidebar, right-sidebar, grid-
 
 Requires at least: 4.4
 Tested up to: 4.6.1
-Stable tag: 1.0.5
+Stable tag: 1.0.6
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.txt
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://smartcatdesign.net/smartcat-products/juno-wordpress-theme/
 Author: Smartcat
 Author URI: https://smartcatdesign.net/
 Description: Juno is a professional, multi-purpose theme with many customizable features and a crisp, clean, and modern design. With the emphasis placed on an uncluttered yet elegant design, Juno ensures your site looks great with minimal customization work.
-Version: 1.0.5
+Version: 1.0.6
 License: GNU General Public License v3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.txt
 Text Domain: juno


### PR DESCRIPTION
Copied in inc/css/style.css from most recent Pro updates and removed all Pro-feature CSS rules, leaving only the new styling and spacing for generic widgets like Calendar, Categories etc.

Also updated Juno Free version in root style.css, functions.php, and readme.txt to 1.0.6 (current theme trac version is 1.0.5)